### PR TITLE
Reload the form when the default tracker id is filtered by permission setting

### DIFF
--- a/app/helpers/track_control_helper.rb
+++ b/app/helpers/track_control_helper.rb
@@ -4,7 +4,7 @@
          tracker_list=project.trackers.select{|t| User.current.allowed_to?("create_#{t.name.downcase.gsub(/\ +/,'_')}_tracker".to_sym, project, :global => true)}.collect {|t| [t.name, t.id]}
         unless issue.new_record?
           current_tracker = [issue.tracker.name,issue.tracker.id]
-          tracker_list << current_tracker unless current_tracker.include? current_tracker
+          tracker_list << current_tracker unless tracker_list.include? current_tracker
         end
       else
         tracker_list = project.trackers.collect {|t| [t.name, t.id]}

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -17,7 +17,7 @@
 <% end %>
 
 <% if @issue.safe_attribute? 'subject' %>
-<p><%= f.text_field :subject, :size => 80, :required => true %></p>
+<p><%= f.text_field :subject, :size => 80, :maxlength => 255, :required => true %></p>
 <% end %>
 
 <% if @issue.safe_attribute? 'description' %>

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -14,6 +14,31 @@
 
 <% if @issue.safe_attribute? 'tracker_id' %>
 <p><%= display_tracker_select(@project,@issue,f)%></p>
+
+<% if @issue.new_record? %>
+<!-- trigger for form reload -->
+<script>
+$(function() {
+  //validate whether there is a valid tracker available
+  if($('#issue_tracker_id > option').length == 0) {
+    alert("You are NOT allow to create any issue, please contact to system admin!");
+    var currentPath = window.location.pathname;
+    var backToPath = currentPath.substring(0, currentPath.lastIndexOf("/"));
+    location.href=backToPath;
+    //history.go(-1);
+  }
+
+  //reload the form with the valid default tracker_id
+  var default_backend_tracker_id = "<%= @issue.tracker_id %>";
+  var default_online_tracker_id = $("#issue_tracker_id").val();
+  if (default_backend_tracker_id != default_online_tracker_id) {
+    $("#issue_tracker_id").val(default_online_tracker_id);
+    $("#issue_tracker_id").change();
+  }
+});
+</script>
+<% end %>
+
 <% end %>
 
 <% if @issue.safe_attribute? 'subject' %>


### PR DESCRIPTION
When new an issue, the default tracker's customer field will be loaded even it has been excluded by permission control.

In this change, I use javascript to trigger the force reload the form when it happens.
