### PR TITLE
Rewrite of functionality, adding JP locale, ensuring data check on data reception

### DIFF
--- a/app/helpers/track_control_helper.rb
+++ b/app/helpers/track_control_helper.rb
@@ -1,16 +1,19 @@
- module TrackControlHelper
-    def display_tracker_select(project,issue,f)
-      if project.enabled_modules.where(:name => "tracker_permissions").count == 1
-         tracker_list=project.trackers.select{|t| User.current.allowed_to?("create_#{t.name.downcase.gsub(/\ +/,'_')}_tracker".to_sym, project, :global => true)}.collect {|t| [t.name, t.id]}
-        unless issue.new_record?
-          current_tracker = [issue.tracker.name,issue.tracker.id]
-          tracker_list << current_tracker unless tracker_list.include? current_tracker
-        end
-      else
-        tracker_list = project.trackers.collect {|t| [t.name, t.id]}
-      end
-         f.select :tracker_id, tracker_list, {:required => true},
-                  :onchange => "updateIssueFrom('#{escape_javascript project_issue_form_path(project, :id => issue, :format => 'js')}')"
-      end
- end
+module TrackControlHelper
+  def valid_trackers_list(project)
+    project.trackers.select{|t| User.current.allowed_to?("create_tracker#{t.id}".to_sym, project, :global => true)}.collect {|t| [t.name, t.id]}
+  end
 
+  def display_tracker_select(project,issue,f)
+    if project.enabled_modules.where(:name => "tracker_permissions").count == 1
+      tracker_list=valid_trackers_list(project)
+      unless issue.new_record?
+        current_tracker = [issue.tracker.name,issue.tracker.id]
+        tracker_list << current_tracker unless tracker_list.include? current_tracker
+      end
+    else
+      tracker_list = project.trackers.collect {|t| [t.name, t.id]}
+    end
+    f.select :tracker_id, tracker_list, :required => true,
+             :onchange => "updateIssueFrom('#{escape_javascript project_issue_form_path(project, :id => issue, :format => 'js')}')"
+  end
+end

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -16,27 +16,7 @@
 <p><%= display_tracker_select(@project,@issue,f)%></p>
 
 <% if @issue.new_record? %>
-<!-- trigger for form reload -->
-<script>
-$(function() {
-  //validate whether there is a valid tracker available
-  if($('#issue_tracker_id > option').length == 0) {
-    alert("You are NOT allow to create any issue, please contact to system admin!");
-    var currentPath = window.location.pathname;
-    var backToPath = currentPath.substring(0, currentPath.lastIndexOf("/"));
-    location.href=backToPath;
-    //history.go(-1);
-  }
-
-  //reload the form with the valid default tracker_id
-  var default_backend_tracker_id = "<%= @issue.tracker_id %>";
-  var default_online_tracker_id = $("#issue_tracker_id").val();
-  if (default_backend_tracker_id != default_online_tracker_id) {
-    $("#issue_tracker_id").val(default_online_tracker_id);
-    $("#issue_tracker_id").change();
-  }
-});
-</script>
+  <% if valid_trackers_list(@issue.project).empty? then flash[:error] = l(:notice_no_valid_trackers_available); end %>
 <% end %>
 
 <% end %>
@@ -50,7 +30,7 @@ $(function() {
   <%= f.label_for_field :description, :required => @issue.required_attribute?('description') %>
   <%= link_to_function image_tag('edit.png'), '$(this).hide(); $("#issue_description_and_toolbar").show()' unless @issue.new_record? %>
   <%= content_tag 'span', :id => "issue_description_and_toolbar", :style => (@issue.new_record? ? nil : 'display:none') do %>
-    <%= f.text_area :description,
+  <%= f.text_area :description,
                    :cols => 60,
                    :rows => (@issue.description.blank? ? 10 : [[10, @issue.description.length / 50].max, 100].min),
                    :accesskey => accesskey(:edit),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,5 @@
 # English strings go here for Rails i18n
 en:
-  my_label: "My label"
+  trackcontrol_create_tracker: "Create %{value} tracker"
+  notice_no_valid_trackers_available: "No valid trackers available. Please ask a Redmine administrator for assistance."
+  trackcontrol_tracker_not_allowed: "not allowed"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,5 @@
+# English strings go here for Rails i18n
+ja:
+  trackcontrol_create_tracker: "トラッカー「%{value}」を作成"
+  notice_no_valid_trackers_available: "使えるトラッカーが設定されていません。Redmine管理者にお問い合わせください。"
+  trackcontrol_tracker_not_allowed: "は許可されていません"

--- a/init.rb
+++ b/init.rb
@@ -10,8 +10,11 @@ ActionDispatch::Callbacks.to_prepare do
   require_dependency 'issue'
   Issue.send(:include, RedmineTrackControl::IssuePatch)
 
+  require_dependency 'roles_controller'
+  RolesController.send(:include, RedmineTrackControl::RolesControllerPatch)
+
   require_dependency 'issues_controller'
-  RedmineTrackControl::IssuesControllerPatch.perform
+  IssuesController.send(:include, RedmineTrackControl::IssuesControllerPatch)
 end
 
 Redmine::Plugin.register :redmine_track_control do
@@ -24,7 +27,7 @@ Redmine::Plugin.register :redmine_track_control do
 
   project_module :tracker_permissions do
     Tracker.all.each do |t|
-      permission "create_#{t.name.downcase.gsub(/\ +/,'_')}_tracker".to_sym, {:issues => :index}
+      permission "create_tracker#{t.id}".to_sym, {:issues => :index}
     end
   end
 end

--- a/lib/redmine_track_control/issue_patch.rb
+++ b/lib/redmine_track_control/issue_patch.rb
@@ -11,8 +11,8 @@ module RedmineTrackControl
     module InstanceMethods
       private
         def is_valid_tracker
-          tracker_name = "create_#{self.tracker.name.downcase.gsub(/\ +/,'_')}_tracker".to_sym
-          errors.add(:tracker_id,"not allowed") if User.current.allowed_to?(tracker_name, self.project, :global => true).nil?
+          tracker_permission_flag = "create_tracker#{self.tracker.id}".to_sym
+          errors.add(:tracker_id, :invalid) if !User.current.allowed_to?(tracker_permission_flag, self.project, :global => true)
         end
     end
   end

--- a/lib/redmine_track_control/issues_controller_patch.rb
+++ b/lib/redmine_track_control/issues_controller_patch.rb
@@ -16,6 +16,7 @@ module RedmineTrackControl
       def build_new_issue_from_params_with_tracker_control
         build_new_issue_from_params_without_tracker_control
         return true if @issue.project.enabled_modules.where(:name => "tracker_permissions").count == 0
+        return true if User.current.admin?
         if !User.current.allowed_to?("create_tracker#{@issue.tracker.id}".to_sym, @issue.project, :global => true)
           render_error l(:error_no_tracker_in_project)
           return false
@@ -23,8 +24,10 @@ module RedmineTrackControl
       end
 
       def update_issue_from_params_with_tracker_control
+        old_tracker_id = @issue.tracker.id
         update_issue_from_params_without_tracker_control
-        return true if (@issue.project.enabled_modules.where(:name => "tracker_permissions").count == 0) or (params[:tracker_id].blank?) or (@issue.tracker.id == params[:tracker_id])
+        return true if (@issue.project.enabled_modules.where(:name => "tracker_permissions").count == 0) or (params[:tracker_id].blank?) or (old_tracker_id == params[:tracker_id])
+        return true if User.current.admin?
         if !User.current.allowed_to?("create_tracker#{@issue.tracker.id}".to_sym, @issue.project, :global => true)
           render_error l(:error_no_tracker_in_project)
           return false

--- a/lib/redmine_track_control/issues_controller_patch.rb
+++ b/lib/redmine_track_control/issues_controller_patch.rb
@@ -15,12 +15,20 @@ module RedmineTrackControl
     module InstanceMethods
       def build_new_issue_from_params_with_tracker_control
         build_new_issue_from_params_without_tracker_control
-        return false if !User.current.allowed_to?("create_tracker#{@issue.tracker.id}".to_sym, @issue.project, :global => true)
+        return true if @issue.project.enabled_modules.where(:name => "tracker_permissions").count == 0
+        if !User.current.allowed_to?("create_tracker#{@issue.tracker.id}".to_sym, @issue.project, :global => true)
+          render_error l(:error_no_tracker_in_project)
+          return false
+        end
       end
 
       def update_issue_from_params_with_tracker_control
         update_issue_from_params_without_tracker_control
-        return false if !User.current.allowed_to?("create_tracker#{@issue.tracker.id}".to_sym, @issue.project, :global => true)
+        return true if (@issue.project.enabled_modules.where(:name => "tracker_permissions").count == 0) or (params[:tracker_id].blank?) or (@issue.tracker.id == params[:tracker_id])
+        if !User.current.allowed_to?("create_tracker#{@issue.tracker.id}".to_sym, @issue.project, :global => true)
+          render_error l(:error_no_tracker_in_project)
+          return false
+        end
       end
     end
   end

--- a/lib/redmine_track_control/issues_controller_patch.rb
+++ b/lib/redmine_track_control/issues_controller_patch.rb
@@ -1,8 +1,26 @@
 module RedmineTrackControl
   module IssuesControllerPatch
-    def self.perform
-      IssuesController.class_eval do
+    def self.included(base)
+      base.send(:include, InstanceMethods)
+
+      base.class_eval do
+        unloadable
         helper 'track_control'
+
+        alias_method_chain :build_new_issue_from_params, :tracker_control
+        alias_method_chain :update_issue_from_params, :tracker_control
+      end
+    end
+
+    module InstanceMethods
+      def build_new_issue_from_params_with_tracker_control
+        build_new_issue_from_params_without_tracker_control
+        return false if !User.current.allowed_to?("create_tracker#{@issue.tracker.id}".to_sym, @issue.project, :global => true)
+      end
+
+      def update_issue_from_params_with_tracker_control
+        update_issue_from_params_without_tracker_control
+        return false if !User.current.allowed_to?("create_tracker#{@issue.tracker.id}".to_sym, @issue.project, :global => true)
       end
     end
   end

--- a/lib/redmine_track_control/roles_controller_patch.rb
+++ b/lib/redmine_track_control/roles_controller_patch.rb
@@ -1,0 +1,31 @@
+#Patches Redmine's RolesController.
+module RedmineTrackControl
+  module RolesControllerPatch
+    def self.included(base)
+      base.send(:include, InstanceMethods)
+
+      base.class_eval do
+        unloadable
+
+        alias_method_chain :show, :tracker_translations
+        alias_method_chain :permissions, :tracker_translations
+      end
+    end
+
+    module InstanceMethods
+      def show_with_tracker_translations
+        Tracker.all.each do |t|
+          I18n.backend.store_translations(:en, { "permission_create_tracker#{t.id}".to_sym => l(:trackcontrol_create_tracker, t.name) })
+        end
+        show_without_tracker_translations
+      end
+
+      def permissions_with_tracker_translations
+        Tracker.all.each do |t|
+          I18n.backend.store_translations(:en, { "permission_create_tracker#{t.id}".to_sym => l(:trackcontrol_create_tracker, t.name) })
+        end
+        permissions_without_tracker_translations
+      end
+    end
+  end
+end

--- a/lib/redmine_track_control/tracker_patch.rb
+++ b/lib/redmine_track_control/tracker_patch.rb
@@ -19,10 +19,10 @@ module RedmineTrackControl
     module InstanceMethods
       private
       def add_tracker_permission
-        Redmine::AccessControl.map {|map| map.project_module(:tracker_permissions) {|map|map.permission("create_#{name.downcase.gsub(/\ +/,'_')}_tracker".to_sym, {:issues => :index}, {})}}
+        Redmine::AccessControl.map {|map| map.project_module(:tracker_permissions) {|map|map.permission("create_tracker#{id}".to_sym, {:issues => :index}, {})}}
       end
       def remove_tracker_permission
-        perm = Redmine::AccessControl.permission("create_#{name.downcase.gsub(/\ +/,'_')}_tracker".to_sym)
+        perm = Redmine::AccessControl.permission("create_tracker#{id}".to_sym)
         Redmine::AccessControl.permissions.delete perm unless perm.nil?
       end
     end


### PR DESCRIPTION
- More or less did a complete rewrite of the plugin, replaced the use of tracker name by use of tracker ID for permission flags
- Added a patch to RolesController for translating and displaying names in the Permissions screen
- Revamped the IssuesController patch so that now it rejects invalid trackers properly on edit/update/create (it will revert to default behavior if module is disabled, tracker ID parameter not specified in update, or identical to previous value)
- Removed the javascript bit since it didn't prevent direct updates
